### PR TITLE
Fix a warning

### DIFF
--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -738,7 +738,7 @@ class RainTPL{
 			$tags = array_intersect( array( "form" ), self::$path_replace_list );
 			$exp[] = '/<(' . join( '|', $tags ) . ')(.*?)(action)="(' . $url . ')"/i';
 
-			return preg_replace_callback( $exp, 'self::single_path_replace', $html );
+			return preg_replace_callback( $exp, array($this, 'single_path_replace'), $html );
 
 		}
 		else


### PR DESCRIPTION
When a template is modified, a static callback emits this warning:
```Warning: preg_replace_callback() [function.preg-replace-callback]: Requires argument 2, 'self::single_path_replace', to be a valid callback```